### PR TITLE
Bump to 3.0.0. AMQPX is no longer an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,13 @@ def deps do
 end
 ```
 
-Add amqpx as extra_applications:
+From 3.0.0 AMQPX is no longer an application. This is so the client can choose in which environment or configuration to have consumers up and running.
+You would then need to start your consumers and producer in the client's supervision tree, instead of adding AMQPX to the `extra_application` list as it was in the past:
 
 ```elixir
-def application do
-  [
-    extra_applications: [:amqpx]
-  ]
-end
+Enum.each(Application.get_env(:amqpx, :consumers), & Amqpx.Consumer.start_link(&1))
+Amqpx.Producer.start_link(Application.get_env(:amqpx, :producer))
+
 ```
 
 ## Sample configuration

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -1,23 +1,3 @@
 defmodule Amqpx.Application do
   @moduledoc false
-  use Application
-
-  def start(_type, _args) do
-    import Supervisor.Spec, warn: false
-
-    children =
-      consumers(Application.get_env(:amqpx, :consumers) || []) ++
-        [producer(Application.get_env(:amqpx, :producer) || [])]
-
-    opts = [strategy: :one_for_one, name: Amqpx.Supervisor]
-    Supervisor.start_link(children, opts)
-  end
-
-  defp consumers(configs) do
-    Enum.map(configs, &Supervisor.child_spec({Amqpx.Consumer, &1}, id: UUID.uuid1()))
-  end
-
-  defp producer(config) do
-    {Amqpx.Producer, config}
-  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "2.1.0",
+      version: "3.0.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,
@@ -25,7 +25,7 @@ defmodule Amqpx.MixProject do
   def application do
     [
       extra_applications: [:logger],
-      mod: {Amqpx.Application, []}
+      mod: []
     ]
   end
 

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,3 +1,4 @@
-ExUnit.start()
+Enum.each(Application.get_env(:amqpx, :consumers), &Amqpx.Consumer.start_link(&1))
+Amqpx.Producer.start_link(Application.get_env(:amqpx, :producer))
 
-Application.ensure_all_started(:amqpx)
+ExUnit.start()


### PR DESCRIPTION
… is provided, bare consumers and producer need to be handled by the client.