### PR TITLE
Handle consumer crashes 

### DIFF
--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -9,7 +9,7 @@ defmodule Amqpx.Consumer do
 
   @default_prefetch_count 50
   @backoff 5_000
-  @consumer_timeout 10_000
+  # @consumer_timeout 10_000
 
   defstruct [
     :channel,

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -182,7 +182,7 @@ defmodule Amqpx.Consumer do
     # task = Task.async(handler_module, :handle_message, [message, handler_state])
 
     try do
-      handler_module.handle_message(message, handler_state)
+      {:ok, handler_state} = handler_module.handle_message(message, handler_state)
       Basic.ack(state.channel, tag)
       %{state | handler_state: handler_state}
     rescue

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -45,7 +45,7 @@ defmodule Amqpx.Consumer do
   end
 
   @spec broker_connect(state()) :: {:ok, state()}
-  defp broker_connect(%__MODULE__{handler_module: handler_module, queue: queue} = state) do
+  defp broker_connect(%__MODULE__{queue: queue} = state) do
     case Connection.open(Application.get_env(:amqpx, :broker)[:connection_params]) do
       {:ok, connection} ->
         Process.monitor(connection.pid)


### PR DESCRIPTION
Non era gestito il crash dell'handler del consumer. Se crashava l'`handler module` i messaggi rimanevano unacked e la connessione rimaneva in uno stato inconsistente