### PR TITLE
Support for queue options

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ config :amqpx,
       handler_args: [ # default: []
           key: "value",
           # or something else
+      ],
+      queue_options: [
+        durable: true
+        # available options: auto_delete, exclusive, passive, no_wait
       ]
     ],
     [

--- a/config/config.exs
+++ b/config/config.exs
@@ -28,45 +28,4 @@ use Mix.Config
 # here (which is why it is important to import them last).
 #
 
-config :amqpx,
-  consumers: [
-    [
-      handler_module: Amqpx.Test.Support.Consumer1,
-      queue: "test",
-      exchange: "amq.topic",
-      exchange_type: :topic,
-      routing_keys: ["amqpx.test"],
-      queue_dead_letter: "test_errored",
-      queue_dead_letter_exchange: "test_errored_exchange",
-      handler_args: []
-    ],
-    [
-      handler_module: Amqpx.Test.Support.Consumer2,
-      queue: "blabla",
-      exchange: "amq.topic",
-      exchange_type: :topic,
-      routing_keys: ["amqpx.bla"],
-      queue_dead_letter: "test_bla"
-    ]
-  ]
-
-config :amqpx, :producer,
-  publisher_confirms: false,
-  exchanges: [
-    [
-      name: "amq.topic",
-      type: :topic
-    ]
-  ]
-
-config :amqpx, :broker,
-  connection_params: [
-    username: "amqpx",
-    password: "amqpx",
-    host: "rabbit",
-    virtual_host: "amqpx",
-    heartbeat: 30,
-    connection_timeout: 10_000
-  ]
-
 import_config "#{Mix.env()}.exs"

--- a/config/test.exs
+++ b/config/test.exs
@@ -16,7 +16,6 @@ config :amqpx,
       routing_keys: ["amqpx.test1"],
       queue_options: [
         durable: true,
-        passive: true,
         arguments: [
           {"x-dead-letter-routing-key", :longstr, "test1_errored"},
           {"x-dead-letter-exchange", :longstr, "test1_errored_exchange"}

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,7 @@ config :amqpx,
       exchange_type: :topic,
       routing_keys: ["amqpx.test1"],
       queue_dead_letter: "test1_errored",
-      queue_dead_letter_exchange: "test1_errored_exchange_aa",
+      queue_dead_letter_exchange: "test1_errored_exchange",
       queue_options: [
         durable: true
       ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -14,10 +14,13 @@ config :amqpx,
       exchange: "topic1",
       exchange_type: :topic,
       routing_keys: ["amqpx.test1"],
-      queue_dead_letter: "test1_errored",
-      queue_dead_letter_exchange: "test1_errored_exchange",
       queue_options: [
-        durable: true
+        durable: true,
+        passive: true,
+        arguments: [
+          {"x-dead-letter-routing-key", :longstr, "test1_errored"},
+          {"x-dead-letter-exchange", :longstr, "test1_errored_exchange"}
+        ]
       ]
     ],
     [
@@ -26,10 +29,12 @@ config :amqpx,
       exchange: "topic2",
       exchange_type: :topic,
       routing_keys: ["amqpx.test2"],
-      queue_dead_letter: "test2_errored",
-      queue_dead_letter_exchange: nil,
       queue_options: [
-        durable: true
+        durable: true,
+        arguments: [
+          {"x-dead-letter-routing-key", :longstr, "test2_errored"},
+          {"x-dead-letter-exchange", :longstr, "test2_errored_exchange"}
+        ]
       ]
     ]
   ]

--- a/config/test.exs
+++ b/config/test.exs
@@ -15,7 +15,10 @@ config :amqpx,
       exchange_type: :topic,
       routing_keys: ["amqpx.test1"],
       queue_dead_letter: "test1_errored",
-      queue_dead_letter_exchange: "test1_errored_exchange"
+      queue_dead_letter_exchange: "test1_errored_exchange_aa",
+      queue_options: [
+        durable: true
+      ]
     ],
     [
       handler_module: Amqpx.Test.Support.Consumer2,
@@ -23,7 +26,11 @@ config :amqpx,
       exchange: "topic2",
       exchange_type: :topic,
       routing_keys: ["amqpx.test2"],
-      queue_dead_letter: "test2_errored"
+      queue_dead_letter: "test2_errored",
+      queue_dead_letter_exchange: nil,
+      queue_options: [
+        durable: true
+      ]
     ]
   ]
 

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -108,25 +108,6 @@ defmodule Amqpx.Consumer do
     {:ok, %{}}
   end
 
-  defp setup_queue(%__MODULE__{
-         channel: channel,
-         queue: queue,
-         exchange: exchange,
-         exchange_type: exchange_type,
-         routing_keys: routing_keys,
-         queue_options: options
-       }) do
-    {:ok, _} = Queue.declare(channel, queue, options)
-
-    :ok = Exchange.declare(channel, exchange, exchange_type, durable: true)
-
-    Enum.each(routing_keys, fn rk ->
-      :ok = Queue.bind(channel, queue, exchange, routing_key: rk)
-    end)
-
-    {:ok, %{}}
-  end
-
   def handle_info(:setup, state) do
     with {:ok, state} <- broker_connect(state) do
       {:noreply, state}

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -16,10 +16,8 @@ defmodule Amqpx.Consumer do
     :exchange,
     :exchange_type,
     :routing_keys,
-    :queue_dead_letter,
     :handler_module,
     :handler_state,
-    queue_dead_letter_exchange: nil,
     handler_args: [],
     queue_options: [
       durable: true
@@ -85,24 +83,18 @@ defmodule Amqpx.Consumer do
          exchange: exchange,
          exchange_type: exchange_type,
          routing_keys: routing_keys,
-         queue_dead_letter: queue_dead_letter,
-         queue_dead_letter_exchange: queue_dead_letter_exchange,
          queue_options: options
-       })
-       when is_binary(queue_dead_letter) do
+       }) do
+    {"x-dead-letter-routing-key", _, queue_dead_letter} = Enum.find(options[:arguments], &match?({"x-dead-letter-routing-key", _, _},&1))
     # Errored queue
-    {:ok, _} = Queue.declare(channel, queue_dead_letter, options)
+    {:ok, _} = Queue.declare(channel, queue_dead_letter, durable: true)
 
     # Messages that cannot be delivered to any consumer in the main queue will be routed to the error queue
     {:ok, _} =
       Queue.declare(
         channel,
         queue,
-        options ++
-          [
-            {"x-dead-letter-exchange", :longstr, queue_dead_letter_exchange},
-            {"x-dead-letter-routing-key", :longstr, queue_dead_letter}
-          ]
+        options
       )
 
     :ok = Exchange.declare(channel, exchange, exchange_type, durable: true)

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -21,7 +21,9 @@ defmodule Amqpx.Consumer do
     :handler_state,
     queue_dead_letter_exchange: nil,
     handler_args: [],
-    queue_options: []
+    queue_options: [
+      durable: true
+    ]
   ]
 
   @type state() :: %__MODULE__{}

--- a/lib/consumer.ex
+++ b/lib/consumer.ex
@@ -85,7 +85,9 @@ defmodule Amqpx.Consumer do
          routing_keys: routing_keys,
          queue_options: options
        }) do
-    {"x-dead-letter-routing-key", _, queue_dead_letter} = Enum.find(options[:arguments], &match?({"x-dead-letter-routing-key", _, _},&1))
+    {"x-dead-letter-routing-key", _, queue_dead_letter} =
+      Enum.find(options[:arguments], &match?({"x-dead-letter-routing-key", _, _}, &1))
+
     # Errored queue
     {:ok, _} = Queue.declare(channel, queue_dead_letter, durable: true)
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "4.0.1",
+      version: "5.0.0",
       elixir: "~> 1.8",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,


### PR DESCRIPTION
Passaggio da
```
queue_dead_letter: "test1_errored",
queue_dead_letter_exchange: "test1_errored_exchange"
```
a:
```
queue_options: [
   .....
   arguments: [
      {"x-dead-letter-routing-key", :longstr, "test1_errored"},
      {"x-dead-letter-exchange", :longstr, "test1_errored_exchange"}
   ]
]
```