### PR TITLE
Allow exchanges declaration in producer config

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -66,5 +66,13 @@ config :amqpx, Amqpx.Test.Support.Consumer3, %{
 
 config :amqpx, :producer, %{
   publish_timeout: 5_000,
-  publisher_confirms: false
+  publisher_confirms: false,
+  exchanges: [
+    %{
+      name: "public_exchange",
+      type: :topic,
+      opts: [durable: true],
+      routing_keys: ["come.se.fosse.antani"]
+    }
+  ]
 }

--- a/config/test.exs
+++ b/config/test.exs
@@ -69,10 +69,9 @@ config :amqpx, :producer, %{
   publisher_confirms: false,
   exchanges: [
     %{
-      name: "public_exchange",
+      name: "test_exchange",
       type: :topic,
-      opts: [durable: true],
-      routing_keys: ["come.se.fosse.antani"]
+      opts: [durable: true]
     }
   ]
 }

--- a/lib/helper.ex
+++ b/lib/helper.ex
@@ -122,6 +122,14 @@ defmodule Amqpx.Helper do
     Queue.bind(channel, queue, name)
   end
 
+  def setup_exchange(channel, _, %{name: name, type: type, opts: opts}) do
+    Exchange.declare(channel, name, type, opts)
+  end
+
+  def setup_exchange(channel, _, %{name: name, type: type}) do
+    Exchange.declare(channel, name, type)
+  end
+
   def setup_exchange(_chan, _queue, conf) do
     raise "Unhandled exchange configuration #{inspect(conf)}"
   end

--- a/lib/helper.ex
+++ b/lib/helper.ex
@@ -122,15 +122,15 @@ defmodule Amqpx.Helper do
     Queue.bind(channel, queue, name)
   end
 
-  def setup_exchange(channel, _, %{name: name, type: type, opts: opts}) do
+  def setup_exchange(_chan, _queue, conf) do
+    raise "Unhandled exchange configuration #{inspect(conf)}"
+  end
+
+  def setup_exchange(channel, %{name: name, type: type, opts: opts}) do
     Exchange.declare(channel, name, type, opts)
   end
 
-  def setup_exchange(channel, _, %{name: name, type: type}) do
+  def setup_exchange(channel, %{name: name, type: type}) do
     Exchange.declare(channel, name, type)
-  end
-
-  def setup_exchange(_chan, _queue, conf) do
-    raise "Unhandled exchange configuration #{inspect(conf)}"
   end
 end

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -13,7 +13,8 @@ defmodule Amqpx.Producer do
     :channel,
     :publisher_confirms,
     publish_timeout: 1_000,
-    backoff: 5_000
+    backoff: 5_000,
+    exchanges: []
   ]
 
   # Public API
@@ -125,7 +126,11 @@ defmodule Amqpx.Producer do
 
   @spec broker_connect(state()) :: state()
   defp broker_connect(
-         %{publisher_confirms: publisher_confirms, connection_params: connection_params} = state
+         %{
+           publisher_confirms: publisher_confirms,
+           connection_params: connection_params,
+           exchanges: exchanges
+         } = state
        ) do
     {:ok, connection} = Connection.open(connection_params)
     Process.monitor(connection.pid)
@@ -133,10 +138,17 @@ defmodule Amqpx.Producer do
     {:ok, channel} = Channel.open(connection)
     state = %{state | channel: channel}
 
+    declare_exchanges(exchanges, channel)
+
     if publisher_confirms do
       Confirm.select(channel)
     end
 
     state
+  end
+
+  defp declare_exchanges(exchanges, channel) do
+    exchanges
+    |> Enum.each(&Amqpx.Helper.setup_exchange(channel, :_, &1))
   end
 end

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -136,6 +136,7 @@ defmodule Amqpx.Producer do
     Process.monitor(connection.pid)
 
     {:ok, channel} = Channel.open(connection)
+    Process.monitor(channel.pid)
     state = %{state | channel: channel}
 
     declare_exchanges(exchanges, channel)

--- a/lib/producer.ex
+++ b/lib/producer.ex
@@ -150,6 +150,6 @@ defmodule Amqpx.Producer do
 
   defp declare_exchanges(exchanges, channel) do
     exchanges
-    |> Enum.each(&Amqpx.Helper.setup_exchange(channel, :_, &1))
+    |> Enum.each(&Amqpx.Helper.setup_exchange(channel, &1))
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.1.0",
+      version: "5.1.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,

--- a/test/amqpx/amqpx_test.exs
+++ b/test/amqpx/amqpx_test.exs
@@ -1,6 +1,6 @@
 defmodule Amqpx.Test.AmqpxTest do
   use ExUnit.Case
-  alias Amqpx.Test.Support.{Consumer1, Consumer2, Producer1, Producer2}
+  alias Amqpx.Test.Support.{Consumer1, Consumer2, Producer1, Producer2, Producer3}
   alias Amqpx.Helper
   import Mock
 
@@ -51,5 +51,11 @@ defmodule Amqpx.Test.AmqpxTest do
         refute called(Consumer1.handle_message(Jason.encode!(payload2), :_, :_))
       end
     end
+  end
+
+  test "e2e: try to publish to an exchange defined in producer conf" do
+    payload = %{test: 1}
+
+    assert Producer3.send_payload(payload) === :ok
   end
 end

--- a/test/support/producer/producer_3.ex
+++ b/test/support/producer/producer_3.ex
@@ -1,0 +1,12 @@
+defmodule Amqpx.Test.Support.Producer3 do
+  @moduledoc nil
+
+  require Logger
+
+  alias Amqpx.Producer
+
+  @spec send_payload(map) :: :ok | :error
+  def send_payload(payload) do
+    Producer.publish("test_exchange", "", Jason.encode!(payload))
+  end
+end


### PR DESCRIPTION
Allow the declaration of exchanges in producer config. Useful for tests.
```elixir
config :amqpx, :producer, %{
  publish_timeout: 5_000,
  publisher_confirms: false,
  exchanges: [
    %{
      name: "test_exchange",
      type: :topic,
      opts: [durable: true]
    }
  ]
}

```