### PR TITLE
[PRIMA-4305]: Automatizzare pubblicazione librerie elixir

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -6,9 +6,9 @@ services:
   - name: rabbit
     image: rabbitmq:3
     environment:
-        RABBITMQ_DEFAULT_VHOST: /
-        RABBITMQ_DEFAULT_USER: guest
-        RABBITMQ_DEFAULT_PASS: guest
+      RABBITMQ_DEFAULT_VHOST: /
+      RABBITMQ_DEFAULT_USER: guest
+      RABBITMQ_DEFAULT_PASS: guest
 
 volumes:
   - name: docker
@@ -95,6 +95,21 @@ steps:
       - mix test
     depends_on:
       - compile-test
+
+  - name: publish
+    image: prima/amqpx-ci:1
+    environment:
+      MIX_ENV: dev
+      HEX_AUTH_KEY:
+        from_secret: hex_auth_key
+    commands:
+      - mix compile
+      - ./publish
+    depends_on:
+      - test
+    when:
+      event:
+        - tag
 
   - name: cache-save
     image: prima/drone-tools:1.15.0

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 Amqpx
 =========
 
+[![Hex pm](http://img.shields.io/hexpm/v/amqpx.svg?style=flat)](https://hex.pm/packages/amqpx)
+[![Build Status](https://drone-1.prima.it/api/badges/primait/amqpx/status.svg)](https://drone-1.prima.it/primait/amqpx)
+
 ## About
 A simple Amqp library based on [official elixir amqp client](https://hex.pm/packages/amqp)
 Written to prevent duplicated and boilerplate code to handle all the lifecycle of the amqp connection. Write your publisher or consumer and forget about the rest!

--- a/config/config.exs
+++ b/config/config.exs
@@ -1,31 +1,3 @@
-# This file is responsible for configuring your application
-# and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
-
-# This configuration is loaded before any dependency and is restricted
-# to this project. If another project depends on this project, this
-# file won't be loaded nor affect the parent project. For this reason,
-# if you want to provide default values for your application for
-# third-party users, it should be done in your "mix.exs" file.
-
-# You can configure your application as:
-#
-#     config :amqpx, key: :value
-#
-# and access this configuration in your application as:
-#
-#     Application.get_env(:amqpx, :key)
-#
-# You can also configure a third-party app:
-#
-#     config :logger, level: :info
-#
-
-# It is also possible to import configuration files, relative to this
-# directory. For example, you can emulate configuration per environment
-# by uncommenting the line below and defining dev.exs, test.exs and such.
-# Configuration from the imported file will override the ones defined
-# here (which is why it is important to import them last).
-#
 
 import_config "#{Mix.env()}.exs"

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.3.1",
+      version: version(),
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,
@@ -69,5 +69,13 @@ defmodule Amqpx.MixProject do
 
   def description do
     "Fork of the AMQP library with some improvements and facilities"
+  end
+
+  defp version do
+    if File.exists?("VERSION") do
+      String.trim(File.read!("VERSION"))
+    else
+      "0.1.0"
+    end
   end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -72,10 +72,12 @@ defmodule Amqpx.MixProject do
   end
 
   defp version do
-    if File.exists?("VERSION") do
-      String.trim(File.read!("VERSION"))
-    else
-      "0.1.0"
+    drone_tag = System.get_env("DRONE_TAG")
+
+    case drone_tag do
+      "" -> "0.0.0-dev"
+      nil -> "0.0.0-dev"
+      _ -> drone_tag
     end
   end
 end

--- a/publish
+++ b/publish
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+#
+# Workaround due to unsupported non-interactive publish process
+#
+
+# Create temporary version file
+echo "$DRONE_TAG" > VERSION
+
+# Authentication
+mix hex.config api_key $HEX_AUTH_KEY
+
+# Verify
+mix hex.user whoami
+
+# Publish
+mix hex.publish --yes --dry-run

--- a/publish
+++ b/publish
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-#
-# Workaround due to unsupported non-interactive publish process
-#
-
 # Create temporary version file
 echo "$DRONE_TAG" > VERSION
 

--- a/publish
+++ b/publish
@@ -1,7 +1,6 @@
 #!/bin/bash
 
-# Create temporary version file
-echo "$DRONE_TAG" > VERSION
+set -e
 
 # Authentication
 mix hex.config api_key $HEX_AUTH_KEY

--- a/publish
+++ b/publish
@@ -14,4 +14,4 @@ mix hex.config api_key $HEX_AUTH_KEY
 mix hex.user whoami
 
 # Publish
-mix hex.publish --yes --dry-run
+mix hex.publish --yes


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMA-4305 

Dato che al momento del deploy viene chiesta la versione su suite-py ho fatto in modo che la stessa versione venga utilizzata per la release su hex.pm.
Sembrava più complesso di quello che è...

Ditemi che ne pensate, magari possiamo applicarlo ad altre librerie sia già esistenti che in futuro...
