### PR TITLE
Fix error ConnectionManager broker connection error handling

### DIFF
--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -36,7 +36,7 @@ defmodule Amqpx.Gen.ConnectionManager do
 
       error ->
         Logger.error("Unable to connect to Broker! Retrying with #{backoff}ms backoff",
-          error: error
+          error: inspect(error)
         )
 
         Process.send_after(self(), {:shutdown, error}, backoff, [])


### PR DESCRIPTION
Fix `Amqpx.Gen.ConnectionManager` trying to match against `{:ok, _}` when opening a connection. Also, the GenServer was sleeping for `backoff` seconds before responding, causing producer/consumer processes restarting in a very short time and shutting down the application.