### PR TITLE
[PRIMA-8108]: AMQPX genera log in chiaro

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
-Amqpx
-=========
+# Amqpx
 
 [![Hex pm](http://img.shields.io/hexpm/v/amqpx.svg?style=flat)](https://hex.pm/packages/amqpx)
 [![Build Status](https://drone-1.prima.it/api/badges/primait/amqpx/status.svg)](https://drone-1.prima.it/primait/amqpx)
 
 ## About
+
 A simple Amqp library based on [official elixir amqp client](https://hex.pm/packages/amqp)
 Written to prevent duplicated and boilerplate code to handle all the lifecycle of the amqp connection. Write your publisher or consumer and forget about the rest!
 
@@ -13,7 +13,7 @@ Written to prevent duplicated and boilerplate code to handle all the lifecycle o
 ```elixir
 def deps do
   [
-    {:amqpx, "~> 5.3"}
+    {:amqpx, "~> 5.4"}
   ]
 end
 ```
@@ -22,6 +22,7 @@ From 3.0.0 Amqpx is no longer an application. This is so the client can choose i
 You would then need to start your consumers and producer in the client's supervision tree, instead of adding Amqpx to the `extra_application` list as it was in the past.
 
 To start all consumers and producer inside your application, using the library helper function:
+
 ```elixir
 defmodule Application do
   alias Amqpx.Helper
@@ -43,13 +44,14 @@ defmodule Application do
           Application.get_env(:myapp, :consumers)
         )
       )
-    opts = [strategy: :one_for_one, name: Supervisor, max_restarts: 5] # set this accordingly with your consumers count, ex: max_restarts: n_consumer + 5 
+    opts = [strategy: :one_for_one, name: Supervisor, max_restarts: 5] # set this accordingly with your consumers count, ex: max_restarts: n_consumer + 5
     Supervisor.start_link(children, opts)
   end
 end
 ```
 
 Start consumers and producer manually:
+
 ```elixir
 Amqpx.Gen.ConnectionManager.start_link(%{connection_params: Application.get_env(:myapp, :amqp_connection)})
 
@@ -61,6 +63,7 @@ Enum.each(Application.get_env(:myapp, :consumers), &Amqpx.Gen.Consumer.start_lin
 ## Sample configuration
 
 ### Connection
+
 ```elixir
 config :myapp,
   amqp_connection: [
@@ -70,12 +73,15 @@ config :myapp,
     port: 5_000,
     virtual_host: "amqpx",
     heartbeat: 30,
-    connection_timeout: 10_000
+    connection_timeout: 10_000,
+    obfuscate_password: false, # default is true
   ]
 ```
 
 ### Consumers
+
 Default parameters:
+
 - prefetch_count: 50
 - backoff: 5_000 (connection retry)
 
@@ -105,17 +111,19 @@ config :myapp, Myapp.Consumer, %{
         {"x-dead-letter-exchange", :longstr, ""}
       ]
     ]
-  }      
+  }
 ```
 
 ### Producers
+
 Default parameters:
+
 - publish_timeout: 1_000
 - backoff: 5_000 (connection retry)
 - exchanges: []
 
 You can also declare exchanges from the producer module, simply specify them in the configuration. There is an example below.
- 
+
 ```elixir
 config :myapp, :producer, %{
   publisher_confirms: false,
@@ -125,9 +133,11 @@ config :myapp, :producer, %{
   ]
 }
 ```
+
 ## Usage example
 
 ### Consumer
+
 ```elixir
 defmodule Myapp.Consumer do
   @moduledoc nil
@@ -155,6 +165,7 @@ end
 ```
 
 ### Producer
+
 ```elixir
 defmodule Myapp.Producer do
   @moduledoc nil

--- a/config/test.exs
+++ b/config/test.exs
@@ -13,7 +13,8 @@ config :amqpx,
     host: "rabbit",
     virtual_host: "/",
     heartbeat: 30,
-    connection_timeout: 10_000
+    connection_timeout: 10_000,
+    obfuscate_password: false
   ]
 
 config :amqpx,

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -5,7 +5,7 @@ defmodule Amqpx.Connection do
 
   import Amqpx.Core
 
-  alias Amqpx.Connection
+  alias Amqpx.{Connection, Helper}
 
   defstruct [:pid]
   @type t :: %Connection{pid: pid}
@@ -146,7 +146,7 @@ defmodule Amqpx.Connection do
 
     amqp_params_network(
       username: keys_get(options, params, :username),
-      password: :credentials_obfuscation.decrypt(keys_get(options, params, :password)),
+      password: Helper.get_password(options),
       virtual_host: keys_get(options, params, :virtual_host),
       host: options |> keys_get(params, :host) |> to_charlist,
       port: keys_get(options, params, :port),
@@ -169,7 +169,7 @@ defmodule Amqpx.Connection do
   defp merge_options_to_default(options) do
     amqp_params_network(
       username: Keyword.get(options, :username, "guest"),
-      password: :credentials_obfuscation.decrypt(Keyword.get(options, :password, "guest")),
+      password: Helper.get_password(options),
       virtual_host: Keyword.get(options, :virtual_host, "/"),
       host: options |> Keyword.get(:host, 'localhost') |> to_charlist,
       port: Keyword.get(options, :port, :undefined),

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -146,7 +146,7 @@ defmodule Amqpx.Connection do
 
     amqp_params_network(
       username: keys_get(options, params, :username),
-      password: keys_get(options, params, :password),
+      password: :credentials_obfuscation.decrypt(keys_get(options, params, :password)),
       virtual_host: keys_get(options, params, :virtual_host),
       host: options |> keys_get(params, :host) |> to_charlist,
       port: keys_get(options, params, :port),
@@ -169,7 +169,7 @@ defmodule Amqpx.Connection do
   defp merge_options_to_default(options) do
     amqp_params_network(
       username: Keyword.get(options, :username, "guest"),
-      password: Keyword.get(options, :password, "guest"),
+      password: :credentials_obfuscation.decrypt(Keyword.get(options, :password, "guest")),
       virtual_host: Keyword.get(options, :virtual_host, "/"),
       host: options |> Keyword.get(:host, 'localhost') |> to_charlist,
       port: Keyword.get(options, :port, :undefined),

--- a/lib/amqp/connection.ex
+++ b/lib/amqp/connection.ex
@@ -146,7 +146,7 @@ defmodule Amqpx.Connection do
 
     amqp_params_network(
       username: keys_get(options, params, :username),
-      password: Helper.get_password(options),
+      password: Helper.get_password(options, params),
       virtual_host: keys_get(options, params, :virtual_host),
       host: options |> keys_get(params, :host) |> to_charlist,
       port: keys_get(options, params, :port),
@@ -169,7 +169,7 @@ defmodule Amqpx.Connection do
   defp merge_options_to_default(options) do
     amqp_params_network(
       username: Keyword.get(options, :username, "guest"),
-      password: Helper.get_password(options),
+      password: Helper.get_password(options, nil),
       virtual_host: Keyword.get(options, :virtual_host, "/"),
       host: options |> Keyword.get(:host, 'localhost') |> to_charlist,
       port: Keyword.get(options, :port, :undefined),

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -6,6 +6,7 @@ defmodule Amqpx.Helper do
   alias Amqpx.{Exchange, Queue}
 
   def manager_supervisor_configuration(config) do
+    config = Keyword.put(config, :password, :credentials_obfuscation.encrypt(Keyword.get(config, :password)))
     {Amqpx.Gen.ConnectionManager, %{connection_params: config}}
   end
 

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -6,8 +6,7 @@ defmodule Amqpx.Helper do
   alias Amqpx.{Exchange, Queue}
 
   def manager_supervisor_configuration(config) do
-    config = Keyword.put(config, :password, :credentials_obfuscation.encrypt(Keyword.get(config, :password)))
-    {Amqpx.Gen.ConnectionManager, %{connection_params: config}}
+    {Amqpx.Gen.ConnectionManager, %{connection_params: set_password(config)}}
   end
 
   def consumers_supervisor_configuration(handlers_conf) do
@@ -16,6 +15,26 @@ defmodule Amqpx.Helper do
 
   def producer_supervisor_configuration(producer_conf) do
     {Amqpx.Gen.Producer, producer_conf}
+  end
+
+  def set_password(config) do
+    case Keyword.get(config, :obfuscate_password, false) do
+      true ->
+        Keyword.put(config, :password, :credentials_obfuscation.encrypt(Keyword.get(config, :password)))
+
+      _ ->
+        config
+    end
+  end
+
+  def get_password(config) do
+    case Keyword.get(config, :obfuscate_password, false) do
+      true ->
+        :credentials_obfuscation.decrypt(Keyword.get(config, :password, "guest"))
+
+      _ ->
+        Keyword.get(config, :password, "guest")
+    end
   end
 
   def declare(

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -18,7 +18,7 @@ defmodule Amqpx.Helper do
   end
 
   def set_password(config) do
-    case Keyword.get(config, :obfuscate_password, false) do
+    case Keyword.get(config, :obfuscate_password, true) do
       true ->
         Keyword.put(config, :password, :credentials_obfuscation.encrypt(Keyword.get(config, :password)))
 
@@ -28,7 +28,7 @@ defmodule Amqpx.Helper do
   end
 
   def get_password(config) do
-    case Keyword.get(config, :obfuscate_password, false) do
+    case Keyword.get(config, :obfuscate_password, true) do
       true ->
         :credentials_obfuscation.decrypt(Keyword.get(config, :password, "guest"))
 

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -6,7 +6,7 @@ defmodule Amqpx.Helper do
   alias Amqpx.{Exchange, Queue}
 
   def manager_supervisor_configuration(config) do
-    {Amqpx.Gen.ConnectionManager, %{connection_params: set_password(config)}}
+    {Amqpx.Gen.ConnectionManager, %{connection_params: encrypt_password(config)}}
   end
 
   def consumers_supervisor_configuration(handlers_conf) do
@@ -17,23 +17,33 @@ defmodule Amqpx.Helper do
     {Amqpx.Gen.Producer, producer_conf}
   end
 
-  def set_password(config) do
+  def encrypt_password(config) do
     case Keyword.get(config, :obfuscate_password, true) do
       true ->
-        Keyword.put(config, :password, :credentials_obfuscation.encrypt(Keyword.get(config, :password)))
+        Keyword.put(config, :password, :credentials_obfuscation.encrypt(Keyword.get(config, :password, "guest")))
 
       _ ->
         config
     end
   end
 
-  def get_password(config) do
+  def get_password(config, nil) do
     case Keyword.get(config, :obfuscate_password, true) do
       true ->
         :credentials_obfuscation.decrypt(Keyword.get(config, :password, "guest"))
 
       _ ->
         Keyword.get(config, :password, "guest")
+    end
+  end
+
+  def get_password(config, params) do
+    case Keyword.get(config, :obfuscate_password, true) do
+      true ->
+        :credentials_obfuscation.decrypt(Keyword.get(config, :password, Keyword.get(params, :password)))
+
+      _ ->
+        Keyword.get(config, :password, Keyword.get(params, :password))
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.3.4",
+      version: "5.4.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,

--- a/test/connection_test.exs
+++ b/test/connection_test.exs
@@ -4,28 +4,36 @@ defmodule ConnectionTest do
   import Amqpx.Core
   alias Amqpx.Connection
 
+  @obfuscate_password false
+
   test "open connection with host as binary" do
-    assert {:ok, conn} = Connection.open(host: "rabbit")
+    assert {:ok, conn} = Connection.open(host: "rabbit", obfuscate_password: @obfuscate_password)
     assert :ok = Connection.close(conn)
   end
 
   test "open connection with host as char list" do
-    assert {:ok, conn} = Connection.open(host: 'rabbit')
+    assert {:ok, conn} = Connection.open(host: 'rabbit', obfuscate_password: @obfuscate_password)
     assert :ok = Connection.close(conn)
   end
 
   test "open connection using uri" do
-    assert {:ok, conn} = Connection.open("amqp://rabbit")
+    assert {:ok, conn} = Connection.open("amqp://rabbit", obfuscate_password: @obfuscate_password)
     assert :ok = Connection.close(conn)
   end
 
   test "open connection using both uri and options" do
-    assert {:ok, conn} = Connection.open("amqp://nonexistent:5672", host: 'rabbit')
+    assert {:ok, conn} =
+             Connection.open("amqp://nonexistent:5672", host: 'rabbit', obfuscate_password: @obfuscate_password)
+
     assert :ok = Connection.close(conn)
   end
 
   test "open connection with uri, name, and options" do
-    assert {:ok, conn} = Connection.open("amqp://nonexistent:5672", "my-connection", host: 'rabbit')
+    assert {:ok, conn} =
+             Connection.open("amqp://nonexistent:5672", "my-connection",
+               host: 'rabbit',
+               obfuscate_password: @obfuscate_password
+             )
 
     assert :ok = Connection.close(conn)
   end
@@ -33,7 +41,10 @@ defmodule ConnectionTest do
   test "override uri with options" do
     uri = "amqp://guest:guest@rabbit:5672"
     {:ok, amqp_params} = uri |> String.to_charlist() |> :amqp_uri.parse()
-    record = Connection.merge_options_to_amqp_params(amqp_params, username: "guest")
+
+    record =
+      Connection.merge_options_to_amqp_params(amqp_params, username: "guest", obfuscate_password: @obfuscate_password)
+
     params = amqp_params_network(record)
 
     assert params[:username] == "guest"


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMA-8108 

Use credentials_obfuscation to encrypt password before pushing it into `ConnectionManager` genserver's state.
Password obfuscation is enabled by default.
