### PR TITLE
Add handling of multiple producers

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,2 @@
+erlang 23.1
+elixir 1.11.2-otp-23

--- a/config/test.exs
+++ b/config/test.exs
@@ -76,3 +76,16 @@ config :amqpx, :producer, %{
     }
   ]
 }
+
+config :amqpx, :producer2, %{
+  name: :producer2,
+  publish_timeout: 5_000,
+  publisher_confirms: true,
+  exchanges: [
+    %{
+      name: "test_exchange_2",
+      type: :topic,
+      opts: [durable: true]
+    }
+  ]
+}

--- a/lib/amqp/gen/producer.ex
+++ b/lib/amqp/gen/producer.ex
@@ -19,7 +19,8 @@ defmodule Amqpx.Gen.Producer do
   # Public API
 
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: __MODULE__)
+    name = Map.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
   end
 
   def init(opts) do
@@ -28,9 +29,27 @@ defmodule Amqpx.Gen.Producer do
     {:ok, state}
   end
 
-  @spec publish(String.t(), String.t(), String.t(), Keyword.t()) :: :ok | :error
-  def publish(name, routing_key, payload, options \\ []) do
-    case GenServer.call(__MODULE__, {:publish, {name, routing_key, payload, options}}) do
+  @spec publish(
+          exchange_name :: String.t(),
+          routing_key :: String.t(),
+          payload :: String.t(),
+          options :: Keyword.t()
+        ) ::
+          :ok | :error
+  def publish(exchange_name, routing_key, payload, options \\ []) do
+    publish_by(__MODULE__, exchange_name, routing_key, payload, options)
+  end
+
+  @spec publish_by(
+          producer_name :: GenServer.name(),
+          exchange_name :: String.t(),
+          routing_key :: String.t(),
+          payload :: String.t(),
+          options :: Keyword.t()
+        ) ::
+          :ok | :error
+  def publish_by(producer_name, exchange_name, routing_key, payload, options \\ []) do
+    case GenServer.call(producer_name, {:publish, {exchange_name, routing_key, payload, options}}) do
       :ok ->
         :ok
 

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.4.0",
+      version: "5.5.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,


### PR DESCRIPTION
With this PR it will be possible to setup many producers inside the same supervision tree.  
This could be useful in order to address scenarios where we need producers with different configurations (e.g. one producer using publish confirms and one not).  

The new .tool-versions file you see inside PR is added only to facilitate local development using [asdf version manager](https://asdf-vm.com/). The dumped versions of elixir and erlang are exactly the same used inside the base image of the Dockerfile.