### PR TITLE
[PRIMA-9846]: Add handle message rejection optional callback

### DIFF
--- a/config/test.exs
+++ b/config/test.exs
@@ -28,6 +28,9 @@ config :amqpx,
     %{
       handler_module: Amqpx.Test.Support.Consumer3,
       backoff: 10_000
+    },
+    %{
+      handler_module: Amqpx.Test.Support.HandleRejectionConsumer
     }
   ]
 
@@ -47,9 +50,7 @@ config :amqpx, Amqpx.Test.Support.Consumer1, %{
 
 config :amqpx, Amqpx.Test.Support.Consumer2, %{
   queue: "test2",
-  exchanges: [
-    %{name: "topic2", type: :topic, routing_keys: ["amqpx.test2"], opts: [durable: true]}
-  ],
+  exchanges: [],
   opts: [
     durable: true,
     arguments: [
@@ -62,6 +63,13 @@ config :amqpx, Amqpx.Test.Support.Consumer3, %{
   queue: "test3",
   exchanges: [
     %{name: "topic3", type: :fanout, opts: [durable: true]}
+  ]
+}
+
+config :amqpx, Amqpx.Test.Support.HandleRejectionConsumer, %{
+  queue: "test-rejection",
+  exchanges: [
+    %{name: "topic-rejection", type: :topic, routing_keys: ["amqpx.test-rejection"], opts: [durable: true]}
   ]
 }
 

--- a/config/test.exs
+++ b/config/test.exs
@@ -30,7 +30,8 @@ config :amqpx,
       backoff: 10_000
     },
     %{
-      handler_module: Amqpx.Test.Support.HandleRejectionConsumer
+      handler_module: Amqpx.Test.Support.HandleRejectionConsumer,
+      backoff: 10
     }
   ]
 
@@ -50,7 +51,9 @@ config :amqpx, Amqpx.Test.Support.Consumer1, %{
 
 config :amqpx, Amqpx.Test.Support.Consumer2, %{
   queue: "test2",
-  exchanges: [],
+  exchanges: [
+    %{name: "topic2", type: :topic, routing_keys: ["amqpx.test2"]}
+  ],
   opts: [
     durable: true,
     arguments: [
@@ -69,7 +72,12 @@ config :amqpx, Amqpx.Test.Support.Consumer3, %{
 config :amqpx, Amqpx.Test.Support.HandleRejectionConsumer, %{
   queue: "test-rejection",
   exchanges: [
-    %{name: "topic-rejection", type: :topic, routing_keys: ["amqpx.test-rejection"], opts: [durable: true]}
+    %{
+      name: "topic-rejection",
+      type: :topic,
+      routing_keys: ["amqpx.test-rejection"],
+      opts: [redelivered: true]
+    }
   ]
 }
 

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -21,7 +21,7 @@ defmodule Amqpx.Gen.Consumer do
   @callback handle_message(any(), map(), map()) :: {:ok, map()} | {:error, any()}
   @callback handle_message_rejection(any()) :: {:ok} | {:error, any()}
   @optional_callbacks handle_message_rejection: 1
-  
+
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
   end

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -198,14 +198,17 @@ defmodule Amqpx.Gen.Consumer do
     e in _ ->
       Logger.error(inspect(e))
 
+      is_message_to_reject = function_exported?(handler_module, :handle_message_rejection, 1) && !redelivered
+
       Task.start(fn ->
         :timer.sleep(backoff)
-        IO.puts("REACHED HANDLE_MESSAGE_REJECTION 1/2")
 
-        case function_exported?(handler_module, :handle_message_rejection, 1) && redelivered do
+        case is_message_to_reject do
           true ->
-            IO.puts("REACHED HANDLE_MESSAGE_REJECTION 2/2")
             handler_module.handle_message_rejection(e)
+
+          false ->
+            nil
         end
 
         Basic.reject(state.channel, tag, requeue: !redelivered)

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -20,10 +20,13 @@ defmodule Amqpx.Gen.Consumer do
   @callback setup(Channel.t()) :: {:ok, map()} | {:error, any()}
   @callback handle_message(any(), map(), map()) :: {:ok, map()} | {:error, any()}
   @callback handle_message_rejection(any()) :: {:ok} | {:error, any()}
+
   defmacro __using__(_params) do
     quote do
       @behaviour Amqpx.Gen.Consumer
-      def handle_message_rejection(_, do: {:ok})
+      def handle_message_rejection(_error) do
+        {:ok}
+      end
 
       defoverridable handle_message_rejection: 1
     end

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -21,6 +21,7 @@ defmodule Amqpx.Gen.Consumer do
   @callback handle_message(any(), map(), map()) :: {:ok, map()} | {:error, any()}
   @callback handle_message_rejection(any()) :: {:ok} | {:error, any()}
   @optional_callbacks handle_message_rejection: 1
+  
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
   end

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -198,7 +198,9 @@ defmodule Amqpx.Gen.Consumer do
     e in _ ->
       Logger.error(inspect(e))
 
-      is_message_to_reject = function_exported?(handler_module, :handle_message_rejection, 1) && redelivered
+      is_message_to_reject =
+        function_exported?(handler_module, :handle_message_rejection, 1) &&
+          redelivered
 
       Task.start(fn ->
         :timer.sleep(backoff)

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -203,12 +203,8 @@ defmodule Amqpx.Gen.Consumer do
       Task.start(fn ->
         :timer.sleep(backoff)
 
-        case is_message_to_reject do
-          true ->
-            handler_module.handle_message_rejection(e)
-
-          false ->
-            nil
+        if is_message_to_reject do
+          handler_module.handle_message_rejection(e)
         end
 
         Basic.reject(state.channel, tag, requeue: !redelivered)

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -198,7 +198,7 @@ defmodule Amqpx.Gen.Consumer do
     e in _ ->
       Logger.error(inspect(e))
 
-      is_message_to_reject = function_exported?(handler_module, :handle_message_rejection, 1) && !redelivered
+      is_message_to_reject = function_exported?(handler_module, :handle_message_rejection, 1) && redelivered
 
       Task.start(fn ->
         :timer.sleep(backoff)

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -199,12 +199,12 @@ defmodule Amqpx.Gen.Consumer do
     e in _ ->
       Logger.error(inspect(e))
 
-      is_message_to_reject =
-        function_exported?(handler_module, :handle_message_rejection, 1) &&
-          redelivered
-
       Task.start(fn ->
         :timer.sleep(backoff)
+
+        is_message_to_reject =
+          function_exported?(handler_module, :handle_message_rejection, 1) &&
+            redelivered
 
         if is_message_to_reject do
           handler_module.handle_message_rejection(e)

--- a/test/gen_test.exs
+++ b/test/gen_test.exs
@@ -89,16 +89,16 @@ defmodule Amqpx.Test.AmqpxTest do
 
   test "e2e: should handle message rejected when handle message fails" do
     test_pid = self()
-
+    error_message = "test_error"
     with_mock(HandleRejectionConsumer,
-      handle_message: fn _, _, _ -> raise "error" end,
-      handle_message_rejection: fn _ -> send(test_pid, {:ok, :from_handle_message_rejection}) end
+      handle_message: fn _, _, _ -> raise error_message end,
+      handle_message_rejection: fn error -> send(test_pid, {:ok, error.message}) end
     ) do
       publish_result =
         Amqpx.Gen.Producer.publish("topic-rejection", "amqpx.test-rejection", "some-message", redeliver: false)
 
       assert publish_result == :ok
-      assert_receive {:ok, :from_handle_message_rejection}, 1_000
+      assert_receive {:ok, ^error_message}, 1_000
     end
   end
 end

--- a/test/gen_test.exs
+++ b/test/gen_test.exs
@@ -75,7 +75,6 @@ defmodule Amqpx.Test.AmqpxTest do
         end
       ) do
         publish_1_result = Amqpx.Gen.Producer.publish("topic1", "amqpx.test1", "some-message")
-
         publish_2_result = Amqpx.Gen.Producer.publish_by(:producer2, "topic2", "amqpx.test2", "some-message-2")
 
         assert publish_1_result == :ok

--- a/test/gen_test.exs
+++ b/test/gen_test.exs
@@ -75,6 +75,7 @@ defmodule Amqpx.Test.AmqpxTest do
         end
       ) do
         publish_1_result = Amqpx.Gen.Producer.publish("topic1", "amqpx.test1", "some-message")
+
         publish_2_result = Amqpx.Gen.Producer.publish_by(:producer2, "topic2", "amqpx.test2", "some-message-2")
 
         assert publish_1_result == :ok
@@ -92,13 +93,13 @@ defmodule Amqpx.Test.AmqpxTest do
 
     with_mock(HandleRejectionConsumer,
       handle_message: fn _, _, _ -> raise "error" end,
-      handle_message_rejection: fn _ -> send(test_pid, {:ok}) end
+      handle_message_rejection: fn _ -> send(test_pid, {:ok, :from_handle_message_rejection}) end
     ) do
       publish_result =
-        Amqpx.Gen.Producer.publish("topic-rejection", "amqpx.test-rejection", "some-message", requeue: true)
+        Amqpx.Gen.Producer.publish("topic-rejection", "amqpx.test-rejection", "some-message", redeliver: false)
 
       assert publish_result == :ok
-      assert_receive {:ok}
+      assert_receive {:ok, :from_handle_message_rejection}, 1_000
     end
   end
 end

--- a/test/gen_test.exs
+++ b/test/gen_test.exs
@@ -90,6 +90,7 @@ defmodule Amqpx.Test.AmqpxTest do
   test "e2e: should handle message rejected when handle message fails" do
     test_pid = self()
     error_message = "test_error"
+
     with_mock(HandleRejectionConsumer,
       handle_message: fn _, _, _ -> raise error_message end,
       handle_message_rejection: fn error -> send(test_pid, {:ok, error.message}) end

--- a/test/support/consumer/consumer_handle_rejection.ex
+++ b/test/support/consumer/consumer_handle_rejection.ex
@@ -1,0 +1,21 @@
+defmodule Amqpx.Test.Support.HandleRejectionConsumer do
+  @moduledoc nil
+  @behaviour Amqpx.Gen.Consumer
+
+  alias Amqpx.Basic
+  alias Amqpx.Helper
+
+  def setup(channel) do
+    Helper.declare(channel, Application.fetch_env!(:amqpx, __MODULE__))
+    Basic.consume(channel, Application.fetch_env!(:amqpx, __MODULE__)[:queue], self())
+    {:ok, %{}}
+  end
+
+  def handle_message_rejection(_) do
+    {:ok}
+  end
+
+  def handle_message(_payload, _meta, _state) do
+    raise "test error"
+  end
+end


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMA-9846

This PR aims to add an optional callback that gets triggered whenever an handle_message callback (or a Basic.ack) fail and the redelivered option is set to true. I'm still pretty new to elixir/beam ecosystem and functional programming so please challenge my proposal in any way possible 😄.
