### PR TITLE
message pass through to rejection handler

### DIFF
--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -19,8 +19,8 @@ defmodule Amqpx.Gen.Consumer do
 
   @callback setup(Channel.t()) :: {:ok, map()} | {:error, any()}
   @callback handle_message(any(), map(), map()) :: {:ok, map()} | {:error, any()}
-  @callback handle_message_rejection(any()) :: {:ok} | {:error, any()}
-  @optional_callbacks handle_message_rejection: 1
+  @callback handle_message_rejection(message :: any(), error :: any()) :: :ok | {:error, any()}
+  @optional_callbacks handle_message_rejection: 2
 
   def start_link(opts) do
     GenServer.start_link(__MODULE__, opts)
@@ -203,11 +203,11 @@ defmodule Amqpx.Gen.Consumer do
         :timer.sleep(backoff)
 
         is_message_to_reject =
-          function_exported?(handler_module, :handle_message_rejection, 1) &&
+          function_exported?(handler_module, :handle_message_rejection, 2) &&
             redelivered
 
         if is_message_to_reject do
-          handler_module.handle_message_rejection(e)
+          handler_module.handle_message_rejection(message, e)
         end
 
         Basic.reject(state.channel, tag, requeue: !redelivered)

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.7.0",
+      version: "5.7.1",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,

--- a/test/gen_test.exs
+++ b/test/gen_test.exs
@@ -93,7 +93,7 @@ defmodule Amqpx.Test.AmqpxTest do
 
     with_mock(HandleRejectionConsumer,
       handle_message: fn _, _, _ -> raise error_message end,
-      handle_message_rejection: fn error -> send(test_pid, {:ok, error.message}) end
+      handle_message_rejection: fn _, error -> send(test_pid, {:ok, error.message}) end
     ) do
       publish_result =
         Amqpx.Gen.Producer.publish("topic-rejection", "amqpx.test-rejection", "some-message", redeliver: false)

--- a/test/support/consumer/consumer_handle_rejection.ex
+++ b/test/support/consumer/consumer_handle_rejection.ex
@@ -11,8 +11,8 @@ defmodule Amqpx.Test.Support.HandleRejectionConsumer do
     {:ok, %{}}
   end
 
-  def handle_message_rejection(_) do
-    {:ok}
+  def handle_message_rejection(_msg, _err) do
+    :ok
   end
 
   def handle_message(_payload, _meta, _state) do


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/PRIMA-9846

This PR includes:

- Small fix to change the return type of `handle_message_rejection` callback from `{:ok}` to `:ok`
- `handle_message_rejection` now also has the rejected message as input for better observability 
