### PR TITLE
[CAB-4786]: Add support for multiple connections

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -96,6 +96,7 @@ steps:
 - name: elixir-test
   image: prima/amqpx-ci:${DRONE_COMMIT}
   commands:
+  - sleep 15
   - mix test
   environment:
     MIX_ENV: test
@@ -150,6 +151,13 @@ services:
     RABBITMQ_PASSWORD: amqpx
     RABBITMQ_USERNAME: amqpx
     RABBITMQ_VHOST: /
+
+- name: rabbit_two
+  image: public.ecr.aws/bitnami/rabbitmq:3.8
+  environment:
+    RABBITMQ_PASSWORD: amqpx
+    RABBITMQ_USERNAME: amqpx
+    RABBITMQ_VHOST: /two
 
 volumes:
 - name: docker

--- a/.drone.yml
+++ b/.drone.yml
@@ -96,7 +96,6 @@ steps:
 - name: elixir-test
   image: prima/amqpx-ci:${DRONE_COMMIT}
   commands:
-  - sleep 15
   - mix test
   environment:
     MIX_ENV: test

--- a/.drone.yml
+++ b/.drone.yml
@@ -16,7 +16,7 @@ steps:
     PLUGIN_DEPTH: 5
 
 - name: cache-restore
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - . /etc/profile.d/ecs-credentials-endpoint
   - cache-restore
@@ -31,7 +31,7 @@ steps:
   - git-clone
 
 - name: check-secrets
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - . /etc/profile.d/ecs-credentials-endpoint
   - check-secrets-grants
@@ -42,14 +42,14 @@ steps:
   - git-clone
 
 - name: check-public-docker-images
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - check-public-docker-images
   depends_on:
   - git-clone
 
 - name: build-image
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - sed -i 's/USER app/USER root/g' ./Dockerfile
   - docker build -t prima/amqpx-ci:${DRONE_COMMIT} ./
@@ -121,7 +121,7 @@ steps:
   - elixir-compile
 
 - name: cache-save
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - . /etc/profile.d/ecs-credentials-endpoint
   - cache-save _build deps
@@ -188,7 +188,7 @@ steps:
     PLUGIN_DEPTH: 5
 
 - name: cache-restore
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - . /etc/profile.d/ecs-credentials-endpoint
   - cache-restore
@@ -203,7 +203,7 @@ steps:
   - git-clone
 
 - name: build-image
-  image: public.ecr.aws/prima/drone-tools:1.21.2
+  image: public.ecr.aws/prima/drone-tools:1.21.3
   commands:
   - sed -i 's/USER app/USER root/g' ./Dockerfile
   - docker build -t prima/amqpx-ci:${DRONE_COMMIT} ./
@@ -280,6 +280,6 @@ depends_on:
 
 ---
 kind: signature
-hmac: 2ece4ca777aa4a03f2e51978bf2f04076998b5f887f9fd34ced41e4acd02fdfa
+hmac: 1106a5cc56fa49f871ee25292707466ce0a7bc1bd1565aad8ab55972095de248
 
 ...

--- a/config/test.exs
+++ b/config/test.exs
@@ -18,6 +18,18 @@ config :amqpx,
   ]
 
 config :amqpx,
+  amqp_connection_two: [
+    name: ConnectionTwo,
+    username: "amqpx",
+    password: "amqpx",
+    host: "rabbit_two",
+    virtual_host: "/two",
+    heartbeat: 30,
+    connection_timeout: 10_000,
+    obfuscate_password: false
+  ]
+
+config :amqpx,
   consumers: [
     %{
       handler_module: Amqpx.Test.Support.Consumer1
@@ -32,6 +44,10 @@ config :amqpx,
     %{
       handler_module: Amqpx.Test.Support.HandleRejectionConsumer,
       backoff: 10
+    },
+    %{
+      handler_module: Amqpx.Test.Support.ConsumerConnectionTwo,
+      connection_name: ConnectionTwo
     }
   ]
 
@@ -81,6 +97,13 @@ config :amqpx, Amqpx.Test.Support.HandleRejectionConsumer, %{
   ]
 }
 
+config :amqpx, Amqpx.Test.Support.ConsumerConnectionTwo, %{
+  queue: "connection-two",
+  exchanges: [
+    %{name: "connection-two", type: :topic, routing_keys: ["amqpx.test_connection_two"]}
+  ]
+}
+
 config :amqpx, :producer, %{
   publish_timeout: 5_000,
   publisher_confirms: false,
@@ -100,6 +123,20 @@ config :amqpx, :producer2, %{
   exchanges: [
     %{
       name: "test_exchange_2",
+      type: :topic,
+      opts: [durable: true]
+    }
+  ]
+}
+
+config :amqpx, :producer_connection_two, %{
+  name: :producer_connection_two,
+  connection_name: ConnectionTwo,
+  publish_timeout: 5_000,
+  publisher_confirms: true,
+  exchanges: [
+    %{
+      name: "test_exchange_connection_two",
       type: :topic,
       opts: [durable: true]
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '2'
+version: "2"
 services:
   web:
     build: .
@@ -8,6 +8,7 @@ services:
     working_dir: $PWD
     links:
       - rabbit
+      - rabbit_two
 
   rabbit:
     image: rabbitmq:3-management
@@ -17,3 +18,12 @@ services:
       RABBITMQ_DEFAULT_PASS: amqpx
     ports:
       - "23555:15672"
+
+  rabbit_two:
+    image: rabbitmq:3-management
+    environment:
+      RABBITMQ_DEFAULT_VHOST: /two
+      RABBITMQ_DEFAULT_USER: amqpx
+      RABBITMQ_DEFAULT_PASS: amqpx
+    ports:
+      - "23556:15672"

--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -14,8 +14,8 @@ defmodule Amqpx.Gen.ConnectionManager do
 
   @type state() :: %__MODULE__{}
 
-  def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts, name: Amqpx.Gen.ConnectionManager)
+  def start_link(%{connection_params: connection_params} = opts) do
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(connection_params, :name) || Amqpx.Gen.ConnectionManager)
   end
 
   def init(opts) do

--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -15,7 +15,7 @@ defmodule Amqpx.Gen.ConnectionManager do
   @type state() :: %__MODULE__{}
 
   def start_link(%{connection_params: connection_params} = opts) do
-    GenServer.start_link(__MODULE__, opts, name: Keyword.get(connection_params, :name) || Amqpx.Gen.ConnectionManager)
+    GenServer.start_link(__MODULE__, opts, name: Keyword.get(connection_params, :name, Amqpx.Gen.ConnectionManager))
   end
 
   def init(opts) do

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -12,7 +12,8 @@ defmodule Amqpx.Gen.Consumer do
     :handler_module,
     :handler_state,
     prefetch_count: 50,
-    backoff: 5_000
+    backoff: 5_000,
+    connection_name: Amqpx.Gen.ConnectionManager
   ]
 
   @type state() :: %__MODULE__{}
@@ -37,10 +38,11 @@ defmodule Amqpx.Gen.Consumer do
         %{
           backoff: backoff,
           prefetch_count: prefetch_count,
-          handler_module: handler_module
+          handler_module: handler_module,
+          connection_name: connection_name
         } = state
       ) do
-    case GenServer.call(Amqpx.Gen.ConnectionManager, :get_connection) do
+    case GenServer.call(connection_name, :get_connection) do
       nil ->
         :timer.sleep(backoff)
         {:stop, :not_ready, state}

--- a/lib/amqp/gen/producer.ex
+++ b/lib/amqp/gen/producer.ex
@@ -13,7 +13,8 @@ defmodule Amqpx.Gen.Producer do
     :publisher_confirms,
     publish_timeout: 1_000,
     backoff: 5_000,
-    exchanges: []
+    exchanges: [],
+    connection_name: Amqpx.Gen.ConnectionManager
   ]
 
   # Public API
@@ -63,9 +64,14 @@ defmodule Amqpx.Gen.Producer do
 
   def handle_info(
         :setup,
-        %{backoff: backoff, publisher_confirms: publisher_confirms, exchanges: exchanges} = state
+        %{
+          backoff: backoff,
+          publisher_confirms: publisher_confirms,
+          exchanges: exchanges,
+          connection_name: connection_name
+        } = state
       ) do
-    case GenServer.call(Amqpx.Gen.ConnectionManager, :get_connection) do
+    case GenServer.call(connection_name, :get_connection) do
       nil ->
         :timer.sleep(backoff)
         {:stop, :not_ready, state}

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.7.2",
+      version: "5.8.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,

--- a/test/support/consumer/consumer_connection_two.ex
+++ b/test/support/consumer/consumer_connection_two.ex
@@ -1,0 +1,17 @@
+defmodule Amqpx.Test.Support.ConsumerConnectionTwo do
+  @moduledoc nil
+  @behaviour Amqpx.Gen.Consumer
+
+  alias Amqpx.Basic
+  alias Amqpx.Helper
+
+  def setup(channel) do
+    Helper.declare(channel, Application.fetch_env!(:amqpx, __MODULE__))
+    Basic.consume(channel, Application.fetch_env!(:amqpx, __MODULE__)[:queue], self())
+    {:ok, %{}}
+  end
+
+  def handle_message(_payload, _meta, state) do
+    {:ok, state}
+  end
+end

--- a/test/support/producer/producer_other_connection.ex
+++ b/test/support/producer/producer_other_connection.ex
@@ -1,0 +1,11 @@
+defmodule Amqpx.Test.Support.ProducerConnectionTwo do
+  @moduledoc nil
+
+  alias Amqpx.Gen.Producer
+
+  @spec send_payload(map) :: :ok | :error
+  def send_payload(payload) do
+    publisher_name = :amqpx |> Application.fetch_env!(:producer_connection_two) |> Map.fetch!(:name)
+    Producer.publish_by(publisher_name, "connection-two", "amqpx.test_connection_two", Jason.encode!(payload))
+  end
+end

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -1,1 +1,17 @@
 ExUnit.start()
+
+stream =
+  Stream.unfold(100, fn x ->
+    with {_, 0} <- System.cmd("curl", ["-s", "--fail", "rabbit:15672"]),
+         {_, 0} <- System.cmd("curl", ["-s", "--fail", "rabbit_two:15672"]) do
+      nil
+    else
+      _ ->
+        IO.puts("Rabbit not ready...")
+        :timer.sleep(500)
+
+        {:ok, x}
+    end
+  end)
+
+Stream.run(stream)


### PR DESCRIPTION
https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/CAB-4786

Add support for multiple connections by adding configuration options in the various Amqpx components. The new options are:
- `:name` in `ConnectionManager`
- `:connection_name` in `Producer` and `Consumer`

We decided to leave `Amqpx.Gen.ConnectionManager` as default for all these options, so this PR should not be a breaking change. The users of this library will be able to create multiple connection managers, multiple producers tied to different connections, and multiple consumers tied to different connections as well