### PR TITLE
[change] print stacktrace when rescuing exceptions

### DIFF
--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -201,7 +201,7 @@ defmodule Amqpx.Gen.Consumer do
     %{state | handler_state: handler_state}
   rescue
     e in _ ->
-      Logger.error(inspect(e))
+      Logger.error(Exception.format(:error, e, __STACKTRACE__))
 
       Task.start(fn ->
         :timer.sleep(backoff)


### PR DESCRIPTION
Hey! I was wondering if it is of any value having the full stacktrace when rescuing general errors while handling messages.
This way we could better understand when some uncaught error occurs (e.g. atm we have some generic "%MatchError" logged from the consumer, but with no other indication on where they happened.
Let me know if it could be ok! :pray: 