### PR TITLE
Default binding for DLX queues instead of wildcard

### DIFF
--- a/entrypoint
+++ b/entrypoint
@@ -4,6 +4,12 @@
 
 if [ "$1" == "mix" ]; then
   exec "$@"
-else [ -n "$1" ];
+elif [ -n "$1" ]; then
   sh -c "$@"
+else
+  mix deps.get
+  mix ecto.setup
+  mix phx.server
+
+  trap : TERM INT; sleep infinity & wait
 fi

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -84,11 +84,11 @@ defmodule Amqpx.Helper do
     setup_queue(channel, queue)
   end
 
-  def setup_dead_lettering(_channel, %{exchange: "", routing_key: ""} = conf) do
+  def setup_dead_lettering(_channel, %{queue: _dlq, exchange: "", routing_key: ""} = conf) do
     raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
-  def setup_dead_lettering(channel, %{exchange: "", routing_key: dlq}) do
+  def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dlq}) do
     # DLX will work through [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default)
     # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -94,7 +94,7 @@ defmodule Amqpx.Helper do
     raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
-  def setup_dead_lettering(_channel, %{queue: q, exchange: "", routing_key: dlq} = conf) do
+  def setup_dead_lettering(_channel, %{queue: q, exchange: "", routing_key: dlq}) do
     raise "Configuring \"x-dead-letter-exchange\" with empty string, \"x-dead-letter-routing-key\" should be #{q}_errored instead of #{dlq}"
   end
 

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -84,9 +84,14 @@ defmodule Amqpx.Helper do
     setup_queue(channel, queue)
   end
 
-  def setup_dead_lettering(channel, %{queue: dlq, exchange: ""}) do
+  def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dql}) do
+    # DLX will work through [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default)
+    # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)
-    # Warn that this DLX won't work unless configured otherwise, or just raise?
+  end
+  
+  def setup_dead_lettering(channel, %{exchange: ""} = conf) do
+    raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -69,7 +69,7 @@ defmodule Amqpx.Helper do
             setup_dead_lettering(channel, %{
               queue: "#{qname}_errored",
               exchange: dle,
-              original_routing_keys: Enum.map(exchanges, &(&1.routing_keys))
+              original_routing_keys: Enum.map(exchanges, & &1.routing_keys)
             })
         end
 
@@ -89,7 +89,7 @@ defmodule Amqpx.Helper do
     # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)
   end
-  
+
   def setup_dead_lettering(_channel, %{exchange: ""} = conf) do
     raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
@@ -103,13 +103,13 @@ defmodule Amqpx.Helper do
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, original_routing_keys: original_routing_keys}) do
     Exchange.declare(channel, exchange, :topic, durable: true)
     Queue.declare(channel, dlq, durable: true)
-    
+
     original_routing_keys
-      |> List.flatten()
-      |> Enum.uniq()
-      |> Enum.each(fn rk ->
-        :ok = Queue.bind(channel, dlq, exchange, routing_key: rk)
-      end)
+    |> List.flatten()
+    |> Enum.uniq()
+    |> Enum.each(fn rk ->
+      :ok = Queue.bind(channel, dlq, exchange, routing_key: rk)
+    end)
   end
 
   def setup_queue(channel, %{

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -91,7 +91,7 @@ defmodule Amqpx.Helper do
   end
 
   def setup_dead_lettering(_channel, %{queue: dlq, exchange: "", routing_key: bad_dlq}) do
-    raise "If x-dead-letter-exchange is empty string, x-dead-letter-routing-key should be '#{dlq}' instead of '#{bad_dlq}'"
+    raise "If x-dead-letter-exchange is an empty string, x-dead-letter-routing-key should be '#{dlq}' instead of '#{bad_dlq}'"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -95,7 +95,7 @@ defmodule Amqpx.Helper do
   end
 
   def setup_dead_lettering(_channel, %{queue: dlq, exchange: "", routing_key: bad_dlq}) do
-    raise "Configuring \"x-dead-letter-exchange\" with empty string, \"x-dead-letter-routing-key\" should be #{dlq} instead of #{bad_dlq}"
+    raise "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be #{dlq} instead of #{bad_dlq}"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -55,9 +55,9 @@ defmodule Amqpx.Helper do
           exchanges: exchanges
         } = queue
       ) do
-    case Enum.find(opts[:arguments], &match?({"x-dead-letter-exchange", _, _}, &1)) do
+    case Enum.find(opts[:arguments], &match?({"x-dead-letter-exchange", :longstr, _}, &1)) do
       {_, _, dle} ->
-        case Enum.find(opts[:arguments], &match?({"x-dead-letter-routing-key", _, _}, &1)) do
+        case Enum.find(opts[:arguments], &match?({"x-dead-letter-routing-key", :longstr, _}, &1)) do
           {_, _, dlrk} ->
             setup_dead_lettering(channel, %{
               queue: "#{qname}_errored",
@@ -88,7 +88,7 @@ defmodule Amqpx.Helper do
     raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
-  def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dlq}) do
+  def setup_dead_lettering(channel, %{exchange: "", routing_key: dlq}) do
     # DLX will work through [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default)
     # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -84,13 +84,13 @@ defmodule Amqpx.Helper do
     setup_queue(channel, queue)
   end
 
-  def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dql}) do
+  def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dlq}) do
     # DLX will work through [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default)
     # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)
   end
   
-  def setup_dead_lettering(channel, %{exchange: ""} = conf) do
+  def setup_dead_lettering(_channel, %{exchange: ""} = conf) do
     raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
@@ -108,7 +108,7 @@ defmodule Amqpx.Helper do
       |> List.flatten()
       |> Enum.uniq()
       |> Enum.each(fn rk ->
-        :ok = Queue.bind(channel, queue, name, routing_key: rk)
+        :ok = Queue.bind(channel, dlq, exchange, routing_key: rk)
       end)
   end
 

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -90,12 +90,8 @@ defmodule Amqpx.Helper do
     Queue.declare(channel, dlq, durable: true)
   end
 
-  def setup_dead_lettering(_channel, %{queue: _dlq, exchange: "", routing_key: ""} = conf) do
-    raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
-  end
-
   def setup_dead_lettering(_channel, %{queue: dlq, exchange: "", routing_key: bad_dlq}) do
-    raise "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be #{dlq} instead of #{bad_dlq}"
+    raise "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be '#{dlq}' instead of '#{bad_dlq}'"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -84,14 +84,18 @@ defmodule Amqpx.Helper do
     setup_queue(channel, queue)
   end
 
-  def setup_dead_lettering(_channel, %{queue: _dlq, exchange: "", routing_key: ""} = conf) do
-    raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
-  end
-
   def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dlq}) do
     # DLX will work through [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default)
     # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)
+  end
+
+  def setup_dead_lettering(_channel, %{queue: _dlq, exchange: "", routing_key: ""} = conf) do
+    raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
+  end
+
+  def setup_dead_lettering(_channel, %{queue: q, exchange: "", routing_key: dlq} = conf) do
+    raise "Configuring \"x-dead-letter-exchange\" with empty string, \"x-dead-letter-routing-key\" should be #{q}_errored instead of #{dlq}"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -94,8 +94,8 @@ defmodule Amqpx.Helper do
     raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
-  def setup_dead_lettering(_channel, %{queue: q, exchange: "", routing_key: dlq}) do
-    raise "Configuring \"x-dead-letter-exchange\" with empty string, \"x-dead-letter-routing-key\" should be #{q}_errored instead of #{dlq}"
+  def setup_dead_lettering(_channel, %{queue: dlq, exchange: "", routing_key: bad_dlq}) do
+    raise "Configuring \"x-dead-letter-exchange\" with empty string, \"x-dead-letter-routing-key\" should be #{dlq} instead of #{bad_dlq}"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -91,7 +91,7 @@ defmodule Amqpx.Helper do
   end
 
   def setup_dead_lettering(_channel, %{queue: dlq, exchange: "", routing_key: bad_dlq}) do
-    raise "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be '#{dlq}' instead of '#{bad_dlq}'"
+    raise "If x-dead-letter-exchange is empty string, x-dead-letter-routing-key should be '#{dlq}' instead of '#{bad_dlq}'"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -84,14 +84,14 @@ defmodule Amqpx.Helper do
     setup_queue(channel, queue)
   end
 
+  def setup_dead_lettering(_channel, %{exchange: "", routing_key: ""} = conf) do
+    raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
+  end
+
   def setup_dead_lettering(channel, %{queue: dlq, exchange: "", routing_key: dlq}) do
     # DLX will work through [default exchange](https://www.rabbitmq.com/tutorials/amqp-concepts.html#exchange-default)
     # since `x-dead-letter-routing-key` matches the queue name
     Queue.declare(channel, dlq, durable: true)
-  end
-
-  def setup_dead_lettering(_channel, %{exchange: ""} = conf) do
-    raise "Incorrect dead letter exchange configuration #{inspect(conf)}"
   end
 
   def setup_dead_lettering(channel, %{queue: dlq, exchange: exchange, routing_key: routing_key}) do

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "5.9.0",
+      version: "6.0.0",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -78,7 +78,7 @@ defmodule HelperTest do
     queue_name_errored = "BadDeadLetterQueue"
 
     assert_raise RuntimeError,
-                 "If x-dead-letter-exchange is empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of '#{queue_name_errored}'",
+                 "If x-dead-letter-exchange is an empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of '#{queue_name_errored}'",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [
@@ -102,7 +102,7 @@ defmodule HelperTest do
     exchange_name = rand_name()
 
     assert_raise RuntimeError,
-                 "If x-dead-letter-exchange is empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of ''",
+                 "If x-dead-letter-exchange is an empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of ''",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -41,7 +41,8 @@ defmodule HelperTest do
     assert {:ok, %{message_count: 0}} = Queue.delete(meta[:chan], queue_name_errored)
   end
 
-  test "configuration without an exchange and with routing key set with correct dead letter queue should not raise an error", meta do
+  test "configuration without an exchange and with routing key set with correct dead letter queue should not raise an error",
+       meta do
     queue_name = rand_name()
     routing_key_name = rand_name()
     exchange_name = rand_name()

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -96,7 +96,7 @@ defmodule HelperTest do
                  end
   end
 
-  test "bad configuration with dead letter exchange and routing key should raise an error", meta do
+  test "bad configuration with empty dead letter exchange and routing key should raise an error", meta do
     queue_name = rand_name()
     routing_key_name = rand_name()
     exchange_name = rand_name()

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -78,7 +78,7 @@ defmodule HelperTest do
     queue_name_errored = "BadDeadLetterQueue"
 
     assert_raise RuntimeError,
-                 "Configuring \"x-dead-letter-exchange\" with empty string, \"x-dead-letter-routing-key\" should be #{queue_name}_errored instead of #{queue_name_errored}",
+                 "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be #{queue_name}_errored instead of #{queue_name_errored}",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -57,7 +57,7 @@ defmodule HelperTest do
                  durable: true,
                  arguments: [
                    {"x-dead-letter-exchange", :longstr, ""},
-                   {"x-dead-letter-routing-key", :longstr, routing_key_name}
+                   {"x-dead-letter-routing-key", :longstr, queue_name_errored}
                  ]
                ],
                queue: queue_name

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -1,0 +1,71 @@
+defmodule HelperTest do
+  use ExUnit.Case
+
+  alias Amqpx.{Channel, Connection, Queue, Exchange, Helper}
+
+  setup do
+    {:ok, conn} = Connection.open(Application.fetch_env!(:amqpx, :amqp_connection))
+    {:ok, chan} = Channel.open(conn)
+    on_exit(fn -> :ok = Connection.close(conn) end)
+    {:ok, conn: conn, chan: chan}
+  end
+
+  test "declare a queue with a bind to an exchange and a dead letter queue with an errored exchange", meta do
+    queue_name = rand_name()
+    routing_key_name = rand_name()
+    exchange_name = rand_name()
+
+    queue_name_errored = "#{queue_name}_errored"
+    exchange_name_errored = "#{exchange_name}_errored"
+
+    assert :ok =
+             Helper.declare(meta[:chan], %{
+               exchanges: [
+                 %{name: exchange_name, opts: [durable: true], routing_keys: [routing_key_name], type: :topic}
+               ],
+               opts: [
+                 durable: true,
+                 arguments: [
+                   {"x-dead-letter-exchange", :longstr, exchange_name_errored},
+                   {"x-dead-letter-routing-key", :longstr, routing_key_name}
+                 ]
+               ],
+               queue: queue_name
+             })
+
+    assert :ok = Queue.unbind(meta[:chan], queue_name, exchange_name)
+    assert :ok = Queue.unbind(meta[:chan], queue_name_errored, exchange_name_errored)
+    assert :ok = Exchange.delete(meta[:chan], exchange_name)
+    assert :ok = Exchange.delete(meta[:chan], exchange_name_errored)
+    assert {:ok, %{message_count: 0}} = Queue.delete(meta[:chan], queue_name)
+    assert {:ok, %{message_count: 0}} = Queue.delete(meta[:chan], queue_name_errored)
+  end
+
+  test "bad configuration with dead letter exchange and routing key should rise an error ", meta do
+    queue_name = rand_name()
+    routing_key_name = rand_name()
+    exchange_name = rand_name()
+
+    assert_raise RuntimeError,
+                 "Incorrect dead letter exchange configuration %{exchange: \"\", queue: \"#{queue_name}_errored\", routing_key: \"\"}",
+                 fn ->
+                   Helper.declare(meta[:chan], %{
+                     exchanges: [
+                       %{name: exchange_name, opts: [durable: true], routing_keys: [routing_key_name], type: :topic}
+                     ],
+                     opts: [
+                       durable: true,
+                       arguments: [
+                         {"x-dead-letter-exchange", :longstr, ""},
+                         {"x-dead-letter-routing-key", :longstr, ""}
+                       ]
+                     ],
+                     queue: queue_name
+                   })
+                 end
+  end
+
+  defp rand_name do
+    :crypto.strong_rand_bytes(8) |> Base.encode64()
+  end
+end

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -78,7 +78,7 @@ defmodule HelperTest do
     queue_name_errored = "BadDeadLetterQueue"
 
     assert_raise RuntimeError,
-                 "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of '#{queue_name_errored}'",
+                 "If x-dead-letter-exchange is empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of '#{queue_name_errored}'",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [
@@ -102,7 +102,7 @@ defmodule HelperTest do
     exchange_name = rand_name()
 
     assert_raise RuntimeError,
-                 "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of ''",
+                 "If x-dead-letter-exchange is empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of ''",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -78,7 +78,7 @@ defmodule HelperTest do
     queue_name_errored = "BadDeadLetterQueue"
 
     assert_raise RuntimeError,
-                 "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be #{queue_name}_errored instead of #{queue_name_errored}",
+                 "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of '#{queue_name_errored}'",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [
@@ -102,7 +102,7 @@ defmodule HelperTest do
     exchange_name = rand_name()
 
     assert_raise RuntimeError,
-                 "Incorrect dead letter exchange configuration %{exchange: \"\", queue: \"#{queue_name}_errored\", routing_key: \"\"}",
+                 "Configuring x-dead-letter-exchange with empty string, x-dead-letter-routing-key should be '#{queue_name}_errored' instead of ''",
                  fn ->
                    Helper.declare(meta[:chan], %{
                      exchanges: [

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -70,7 +70,7 @@ defmodule HelperTest do
     assert {:ok, %{message_count: 0}} = Queue.delete(meta[:chan], queue_name_errored)
   end
 
-  test "bad configuration with dead letter exchange empty and routing key set should rise an error ", meta do
+  test "bad configuration with dead letter exchange empty and routing key set should raise an error", meta do
     queue_name = rand_name()
     routing_key_name = rand_name()
     exchange_name = rand_name()

--- a/test/helper_test.exs
+++ b/test/helper_test.exs
@@ -96,7 +96,7 @@ defmodule HelperTest do
                  end
   end
 
-  test "bad configuration with dead letter exchange and routing key should rise an error ", meta do
+  test "bad configuration with dead letter exchange and routing key should raise an error", meta do
     queue_name = rand_name()
     routing_key_name = rand_name()
     exchange_name = rand_name()


### PR DESCRIPTION
Since rabbitMQ by default [sends messages in DLX with the original routing key](https://www.rabbitmq.com/dlx.html#routing), the default binding for the `*_errored` queue should be the same as the original queue.


Of course things could be very complex if the original queue has more than one exchange etc, but then a DLX may not be feasible at all 🤷🏻

### Example config
```elixir
%{
  exchanges: [
    %{
      name: "exchange_name",
      routing_keys: ["example_key"],
      type: :topic
    }
  ],
  opts: [
    durable: true,
    arguments: [
      {"x-dead-letter-exchange", :longstr, "errors_exchange"}
    ]
  ],
  queue: "queue_name"
}
```
**before:**
```
TO queue_name_errored
ROUTING KEY #
```
**after:**
```
TO queue_name_errored
ROUTING KEY example_key
```