### PR TITLE
[STAFF-31] Add proper shutdown handling to Amqpx generic producers and consumers

### DIFF
--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -26,10 +26,11 @@ defmodule Amqpx.Gen.Consumer do
 
   @gen_server_opts [:name, :timeout, :debug, :spawn_opt, :hibernate_after]
 
+  @spec start_link(opts :: map()) :: GenServer.server()
   def start_link(opts) do
-    [opts, gen_server_opts] = Keyword.split(opts, @gen_server_opts)
+    {gen_server_opts, opts} = Map.split(opts, @gen_server_opts)
 
-    GenServer.start_link(__MODULE__, opts, gen_server_opts)
+    GenServer.start_link(__MODULE__, opts, Map.to_list(gen_server_opts))
   end
 
   def init(opts) do

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -24,8 +24,12 @@ defmodule Amqpx.Gen.Consumer do
   @callback handle_message_rejection(message :: any(), error :: any()) :: :ok | {:error, any()}
   @optional_callbacks handle_message_rejection: 2
 
+  @gen_server_opts [:name, :timeout, :debug, :spawn_opt, :hibernate_after]
+
   def start_link(opts) do
-    GenServer.start_link(__MODULE__, opts)
+    [opts, gen_server_opts] = Keyword.split(opts, @gen_server_opts)
+
+    GenServer.start_link(__MODULE__, opts, gen_server_opts)
   end
 
   def init(opts) do

--- a/lib/amqp/gen/producer.ex
+++ b/lib/amqp/gen/producer.ex
@@ -17,6 +17,8 @@ defmodule Amqpx.Gen.Producer do
 
   @default_backoff [base_ms: 10, max_ms: 5_000]
 
+  @gen_server_opts [:name, :timeout, :debug, :spawn_opt, :hibernate_after]
+
   defstruct [
     :channel,
     :publisher_confirms,
@@ -30,8 +32,11 @@ defmodule Amqpx.Gen.Producer do
   # Public API
 
   def start_link(opts) do
-    name = Map.get(opts, :name, __MODULE__)
-    GenServer.start_link(__MODULE__, opts, name: name)
+    gen_server_opts = opts
+    |> Keyword.take(@gen_server_opts)
+    |> Keyword.put_new(:name, __MODULE__)
+
+    GenServer.start_link(__MODULE__, opts, gen_server_opts)
   end
 
   def init(opts) do

--- a/lib/amqp/gen/producer.ex
+++ b/lib/amqp/gen/producer.ex
@@ -31,10 +31,13 @@ defmodule Amqpx.Gen.Producer do
 
   # Public API
 
+  @spec start_link(opts :: map()) :: GenServer.server()
   def start_link(opts) do
-    gen_server_opts = opts
-    |> Keyword.take(@gen_server_opts)
-    |> Keyword.put_new(:name, __MODULE__)
+    gen_server_opts =
+      opts
+      |> Map.take(@gen_server_opts)
+      |> Map.to_list()
+      |> Keyword.put_new(:name, __MODULE__)
 
     GenServer.start_link(__MODULE__, opts, gen_server_opts)
   end


### PR DESCRIPTION
Previously, the Amqpx producers and consumers did not handle shutdown gracefully, resulting in noisy log messages and a strange behavior when the supervisor attempted to shut them down.

To address this issue and to support use cases where the actors need to be shut down gracefully, I have added a new `terminate` function to the actors implementation. It gracefully shuts down the associated channels when reasons like `:normal`, `:shutdown`, and `{:shutdown, reason :: term()}` are encountered. 

This change also enables the use of the library in distributed environments, where the actors may need to be shut down deliberately, such as when balancing nodes in a cluster.
