### PR TITLE
Avoid logging normal exits

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Written to prevent duplicated and boilerplate code to handle all the lifecycle o
 ```elixir
 def deps do
   [
-    {:amqpx, "~> 6.0.1"}
+    {:amqpx, "~> 6.0.2"}
   ]
 end
 ```

--- a/lib/amqp/gen/consumer.ex
+++ b/lib/amqp/gen/consumer.ex
@@ -178,6 +178,8 @@ defmodule Amqpx.Gen.Consumer do
     {:stop, :channel_exited, state}
   end
 
+  def handle_info({:EXIT, _, :normal}, state), do: {:noreply, state}
+
   def handle_info(message, state) do
     Logger.warn("Unknown message received #{inspect(message)}")
     {:noreply, state}

--- a/lib/amqp/gen/producer.ex
+++ b/lib/amqp/gen/producer.ex
@@ -126,6 +126,8 @@ defmodule Amqpx.Gen.Producer do
     {:stop, :channel_exited, state}
   end
 
+  def handle_info({:EXIT, _, :normal}, state), do: {:noreply, state}
+
   def handle_info(message, state) do
     Logger.warn("Unknown message received #{inspect(message)}")
     {:noreply, state}

--- a/mix.exs
+++ b/mix.exs
@@ -5,7 +5,7 @@ defmodule Amqpx.MixProject do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "6.0.1",
+      version: "6.0.2",
       elixir: "~> 1.7",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,


### PR DESCRIPTION
By using `:trap_exit` for handling shutdowns in consumers and producers, exit messages are received from any linked processes shutting down. Since the catch-all `handle_info` logs all messages without distinction and treats them as warnings, I've added a clause to reduce unnecessary noise