### PR TITLE
Fix connection manager

### DIFF
--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -55,8 +55,6 @@ defmodule Amqpx.Gen.ConnectionManager do
     {:stop, :connection_exited, state}
   end
 
-  def handle_info({:EXIT, _pid, :normal}, state), do: {:stop, :EXIT, state}
-
   def handle_info(message, state) do
     Logger.warn("Unknown message received #{inspect(message)}")
     {:noreply, state}

--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -64,7 +64,10 @@ defmodule Amqpx.Gen.ConnectionManager do
 
   def terminate(_, %__MODULE__{connection: connection}) do
     if Process.alive?(connection.pid) do
-      Connection.close(connection)
+      case Connection.close(connection) do
+        :ok -> :ok
+        error -> Logger.warning("Error while closing connection", error: inspect(error))
+      end
     end
   end
 

--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -19,6 +19,7 @@ defmodule Amqpx.Gen.ConnectionManager do
   end
 
   def init(opts) do
+    Process.flag(:trap_exit, true)
     state = struct(__MODULE__, opts)
     Process.send(self(), :setup, [])
     {:ok, state}

--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -70,7 +70,9 @@ defmodule Amqpx.Gen.ConnectionManager do
 
   @spec connect(map) :: {:ok, Connection.t()} | {:error, any}
   defp connect(connection_params) do
-    with {:ok, connection} <- Connection.open(connection_params) do
+    name = connection_params |> Keyword.get(:name, Amqpx.Gen.ConnectionManager) |> to_string()
+
+    with {:ok, connection} <- Connection.open(connection_params, name) do
       Process.monitor(connection.pid)
 
       {:ok, connection}

--- a/lib/amqp/gen/connection_manager.ex
+++ b/lib/amqp/gen/connection_manager.ex
@@ -64,7 +64,7 @@ defmodule Amqpx.Gen.ConnectionManager do
 
   def terminate(_, %__MODULE__{connection: connection}) do
     if Process.alive?(connection.pid) do
-      Process.exit(connection.pid, :kill)
+      Connection.close(connection)
     end
   end
 


### PR DESCRIPTION
The ConnectionManager module was implementing the GenServer behaviour, with a proper terminate/2 function but it wasn't trapping exits so the terminate wasn't being called (ever). Moreover, it was abrutly closing the connection with an exit/2 call instead of using the proper function.
