### PR TITLE
Remove (useless) flaky test

### DIFF
--- a/test/basic_test.exs
+++ b/test/basic_test.exs
@@ -91,14 +91,5 @@ defmodule BasicTest do
 
       assert {:ok, ^consumer_tag} = Basic.cancel(meta[:chan], consumer_tag)
     end
-
-    test "cancel exits the process when channel is closed", meta do
-      {:ok, consumer_tag} = Basic.consume(meta[:chan], meta[:queue], self())
-
-      Channel.close(meta[:chan])
-
-      Process.flag(:trap_exit, true)
-      assert {:normal, _} = catch_exit(Basic.cancel(meta[:chan], consumer_tag))
-    end
   end
 end


### PR DESCRIPTION
The test was flaky because it was relying on a weird race condition moslty related to the order the processes shutdown when closing a channel; sometimes it failed with
```
  1) test basic consume cancel exits the process when channel is closed (BasicTest)
     test/basic_test.exs:95
     match (=) failed
     code:  assert {:normal, _} = catch_exit(Basic.cancel(meta[:chan], consumer_tag))
     left:  {:normal, _}
     right: {
              :noproc,
              {:gen_server, :call, [#PID<0.372.0>, {:call, {:"basic.cancel", "amq.ctag-7S2NmqLj18nRwk_-O_tQ1A", false}, :none, #PID<0.360.0>}, 70000]}
            }
     stacktrace:
       test/basic_test.exs:103: (test)
```
This can be easily reproduced by simply adding a 
```
:timer.sleep(100)
```
after closing the channel

I'd argue that this test was useless anyway (I still don't understand what the test purpose was) so I simply removed it :shrug:
