### PR TITLE
[DEVEX-2418]: Helper is mandatory since 6.1.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+---
+
+## [6.1.3] - 2025-01-23
+
+### Fixed
+
+- Elixir applications are no more forced to start `Amqpx.SignalHandler` manually
+
 ### Updated
 
 - rabbit libraries to `amqp_client` and `rabbit_common` to 4.0
@@ -105,7 +113,9 @@ This is due to elixir rabbit not supporting the older versions of the libraries
 - ([#129](https://github.com/primait/amqpx/pull/)) Default binding for DLX
   queues instead of wildcard
 
-[Unreleased]: https://github.com/primait/amqpx/compare/6.1.2...HEAD
+
+[Unreleased]: https://github.com/primait/amqpx/compare/6.1.3...HEAD
+[6.1.3]: https://github.com/primait/amqpx/compare/6.1.2...6.1.3
 [6.1.2]: https://github.com/primait/amqpx/compare/6.1.1...6.1.2
 [6.1.1]: https://github.com/primait/amqpx/compare/6.1.0...6.1.1
 [6.1.0]: https://github.com/primait/amqpx/compare/6.0.4...6.1.0

--- a/README.md
+++ b/README.md
@@ -6,16 +6,18 @@
 ## About
 
 A simple Amqp library based on
-[official elixir amqp client](https://hex.pm/packages/amqp) Written to prevent
-duplicated and boilerplate code to handle all the lifecycle of the amqp
-connection. Write your publisher or consumer and forget about the rest!
+[official elixir amqp client](https://hex.pm/packages/amqp).
+
+Written to prevent duplicated and boilerplate code to handle all the lifecycle
+of the amqp connection. Write your publisher or consumer and forget about the
+rest!
 
 ## Installation
 
 ```elixir
 def deps do
   [
-    {:amqpx, "~> 6.0.2"}
+    {:amqpx, "~> 6.1.2"}
   ]
 end
 ```
@@ -250,12 +252,15 @@ end
 
 ### Test suite
 
-In order to run the test suite, you need to startup the docker compose and jump into it with:
+In order to run the test suite, you need to startup the docker compose and jump
+into it with:
+
 ```
 docker compose run --service-ports console bash
 ```
 
 and run the test suite with:
+
 ```
 mix test
 ```

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ rest!
 ```elixir
 def deps do
   [
-    {:amqpx, "~> 6.1.2"}
+    {:amqpx, "~> 6.1.3"}
   ]
 end
 ```

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,17 @@
+apiVersion: backstage.io/v1alpha1
+kind: Component
+spec:
+  type: service
+  lifecycle: production
+  owner: team-developer-experience
+  system: prima.it
+  dependsOn: []
+metadata:
+  name: amqpx
+  description: Elixir AMQP client
+  tags:
+    - elixir
+    - rabbitmq
+  links: []
+  # annotations:
+  #  backstage.io/techdocs-ref: dir:.

--- a/lib/amqp/application.ex
+++ b/lib/amqp/application.ex
@@ -1,0 +1,16 @@
+defmodule Amqpx.Application do
+  @moduledoc false
+  use Application
+
+  def start(_type, _args) do
+    children = [
+      %{
+        id: Amqpx.SignalHandler,
+        start: {Amqpx.SignalHandler, :start_link, []}
+      }
+    ]
+
+    opts = [strategy: :one_for_one, name: Amqpx.Supervisor]
+    Supervisor.start_link(children, opts)
+  end
+end

--- a/lib/amqp/helper.ex
+++ b/lib/amqp/helper.ex
@@ -12,8 +12,7 @@ defmodule Amqpx.Helper do
   end
 
   def consumers_supervisor_configuration(handlers_conf) do
-    amqp_signal_handler() ++
-      Enum.map(handlers_conf, &Supervisor.child_spec({Amqpx.Gen.Consumer, &1}, id: UUID.uuid1()))
+    Enum.map(handlers_conf, &Supervisor.child_spec({Amqpx.Gen.Consumer, &1}, id: UUID.uuid1()))
   end
 
   def producer_supervisor_configuration(producer_conf) do
@@ -189,14 +188,6 @@ defmodule Amqpx.Helper do
   def setup_exchange(channel, %{name: name, type: type}) do
     Exchange.declare(channel, name, type)
   end
-
-  defp amqp_signal_handler,
-    do: [
-      %{
-        id: Amqpx.SignalHandler,
-        start: {Amqpx.SignalHandler, :start_link, []}
-      }
-    ]
 
   defp skip_dead_letter_routing_key_check_for,
     do: Application.get_env(:amqpx, :skip_dead_letter_routing_key_check_for, [])

--- a/mix.exs
+++ b/mix.exs
@@ -1,11 +1,13 @@
 defmodule Amqpx.MixProject do
   use Mix.Project
 
+  @version "6.1.3"
+
   def project do
     [
       app: :amqpx,
       name: "amqpx",
-      version: "6.1.2",
+      version: @version,
       elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :production,

--- a/mix.exs
+++ b/mix.exs
@@ -25,7 +25,8 @@ defmodule Amqpx.MixProject do
   # Run "mix help compile.app" to learn about applications.
   def application do
     [
-      extra_applications: [:logger]
+      extra_applications: [:logger],
+      mod: {Amqpx.Application, []}
     ]
   end
 


### PR DESCRIPTION
Since [amqpx 6.1.1](https://github.com/primait/amqpx/blob/6.1.1/lib/amqp/helper.ex#L184-L190)
applications that didn't use `Helper.consumers_supervisor_configuration/1`
had to manually start `Amqpx.SignalHandler` to avoid crashing
during the [handle_message](https://github.com/primait/amqpx/blob/dcf521f4ffe2de1b53c7770d06b60b562c2bcdbb/lib/amqp/gen/consumer.ex#L258).

This pr reverts that behavior by starting this process under a newly created
amqpx application

https://prima-assicurazioni-spa.myjetbrains.com/youtrack/issue/DEVEX-2418

