### PR TITLE
Add concurrency level option to allow for competing consumers

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ Default parameters:
 
 - prefetch_count: 50
 - backoff: 5_000 (connection retry)
+- requeue_on_reject: true
+- concurrency_level: 1 (requires Amqpx.Helper)
 
 WARNING: headers exchange binding not supported by library helpers functions
 


### PR DESCRIPTION
## Use case

In Prima we usually run rabbit consumers in dedicated worker deployments, each with one consumer per queue.

In case a single consumer is not enough we could parallelize by:

**Adding worker deployments**

- *Pros*:  provision additional resources
- *Cons*: by default it will increase the number of consumers for ALL queues

**Spawning more consumers in a single deployment**

- *Pros*: effective strategy for I/O bounded tasks that wouldn't benefit from additional resources
- *Cons*: cumbersome to implement as it's not supported by the library (see e.g. https://github.com/primait/peano/pull/2592 )

## Proposal

Add an optional `concurrency_level` setting used by the helper to possibly spawn more consumers with the same configuration but independent processes and rabbitmq channels.

The change is backward compatible.